### PR TITLE
Example multi spit

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Test the markup in `data`. Return `true` if the data is a sequence of hickory fo
 
 Convert one supported data type to another. Input data may be hiccup, hiccup-seq, hickory, hickory-seq or html.
 
-Type may be `:hiccup`, `:hiccup-seq`, `:hickory`, `:hickory-seq` or `html`.
+Type may be `:hiccup`, `:hiccup-seq`, `:hickory`, `:hickory-seq` or `:html`.
 
 Example:
 

--- a/examples/quickstart/example-spit-multiple.clj
+++ b/examples/quickstart/example-spit-multiple.clj
@@ -1,0 +1,4 @@
+(let [page (markdown "simple.md")
+      page-green (enlive/at page [:p] (enlive/set-attr :style "color:green;"))]
+  (spit "greens.html" (as-html page-green))
+  page)


### PR DESCRIPTION
An example showing how to output a file with `spit` as well as the usual stdout output so two different files can be generated. See #42 for use cases this is a workaround for. Also fixed a typo in the README.