### PR TITLE
expose enlive/at*

### DIFF
--- a/src/bootleg/enlive.clj
+++ b/src/bootleg/enlive.clj
@@ -10,6 +10,8 @@
   [path loader]
   (-> path file/path-relative io/input-stream loader))
 
+(def at* net.cgrand.enlive-html/at*)
+
 (defmacro at [node-or-nodes & rules]
   `(let [input-type# (or (bootleg.utils/markup-type ~node-or-nodes) :hickory)
          converted-nodes# (bootleg.utils/convert-to ~node-or-nodes :hickory-seq)]


### PR DESCRIPTION
`enlive/at*` is a bit easier to use when programmatically passing selectors and transformations as collection.

I'm not sure if this is the right way of doing it, let me know if you think this should be done differently.