### PR TITLE
Support markdown-clj options (footnotes and reference links)

### DIFF
--- a/src/bootleg/markdown.clj
+++ b/src/bootleg/markdown.clj
@@ -4,11 +4,22 @@
             [markdown.core :as markdown]
             [clojure.java.io :as io]))
 
-(defn markdown [source & options]
+(defn markdown
+  "Converts markdown source (file name) to hiccup-seq (default, see options)
+  available options:
+  
+  :data - treat source as html string instead
+
+  One of:
+  :html, :hiccup, :hiccup-seq, :hickory, :hickory-seq
+
+  markdown-clj options:
+  :footnotes?
+  :reference-links?
+  :parse-meta? - will not return meta but can be used to strip it out at top of file"
+  
+  [source & options]
   (let [flags (into #{} options)
-        markup (if (:data flags)
-                 (markdown/md-to-html-string source)
-                 (let [body (java.io.ByteArrayOutputStream.)]
-                   (markdown/md-to-html (io/input-stream (file/path-relative source)) body)
-                   (.toString body)))]
+        input (if (:data flags) source (slurp (file/path-relative source)))
+        markup (apply markdown/md-to-html-string input (interleave options (repeat true)))]
     (utils/html-output-to flags markup)))

--- a/test/clojure/bootleg/hiccup_test.clj
+++ b/test/clojure/bootleg/hiccup_test.clj
@@ -11,6 +11,12 @@
     (is (= (process-hiccup-data [] "test/files" "(markdown \"simple.md\")")
            '([:h1 "Markdown support"]
              [:p "This is some simple markdown"])))
+    (is (= (process-hiccup-data [] "test/files" "(markdown \"complex.md\" :footnotes? :parse-meta?)")
+           '([:h1 "Markdown support"]
+             [:p "This is some more complex" [:a {:href "#fn-1", :id "fnref1"} [:sup "1"]] " markdown."]
+             [:p "The footnote will appear at the end. "]
+             [:ol {:class "footnotes"} [:li {:id "fn-1"} "Testing optional footnote feature." [:a {:href "#fnref1"} "↩"]]] [:p])
+           ))
     (is (= (process-hiccup-data [] "test/files" "(markdown \"simple.md\" :hickory-seq)")
            '({:type :element
               :attrs nil

--- a/test/files/complex.md
+++ b/test/files/complex.md
@@ -1,0 +1,9 @@
+{:metadata "we'll strip this out"}
+
+# Markdown support
+
+This is some more complex[^comp] markdown.
+
+[^comp]: Testing optional footnote feature.
+
+The footnote will appear at the end.


### PR DESCRIPTION
Great project, I've been playing with babashka and bootleg to generate my site - maybe I'll become one of the examples here later :smile: 

One of the things I'm missing at the moment is that I use footnotes, which is supported by markdown-clj but requires passing it as an option. I took the approach of just extending the use of the existing options and passing them all to markdown-clj too. It makes the API a little weird because the latter takes them in the form `:footnotes? true` whilst bootleg just takes a list of keywords, but it doesn't seem like too big of a deal.

This now uses `md-to-html-string` for both types of sources because using a normal input stream causes `markdown-clj` to output nothing when options are used because the underlying implementation does multiple passes and consumes the stream on the first one. Not sure if there's a meaningful performance hit by reading the whole file in one go - the alternative might be to go fix markdown-clj upstream then update the dependency here, but that's a much longer process :sweat_smile: 

I've not been able to test a native build locally because I'm working on an old computer at the moment and I don't have enough RAM for Graalvm to generate the native image :see_no_evil: - the tests pass in pure Java world though so hopefully everything's OK.

Let me know what you think, happy to change the approach if you think it can be improved. Thanks!